### PR TITLE
no property key when registering field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-ts-decorator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Fixed width file handler with TypeScript Decorator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/fixed-width-convertible.ts
+++ b/src/fixed-width-convertible.ts
@@ -28,7 +28,7 @@ export abstract class FixedWidthConvertible {
    */
   static getAllFields(clz: Record<string, any>): string[] {
     if(!clz) return [];
-    const fields: string[] | undefined = Reflect.getMetadata(fixedWidthVariableKey, clz, fixedWidthVariableKey);
+    const fields: string[] | undefined = Reflect.getMetadata(fixedWidthVariableKey, clz);
     // get `__proto__` and (recursively) all parent classes
     const rs = new Set([...(fields || []), ...this.getAllFields(Object.getPrototypeOf(clz))]);
     return Array.from(rs);

--- a/src/fixed-width-decorator.ts
+++ b/src/fixed-width-decorator.ts
@@ -5,10 +5,12 @@ export const fixedWidthVariableKey = Symbol('fixedWidth:variable');
 
 export function FixedWidth(options: FixedWidthOptions): any {
   return function(target: any, propertyKey: string | symbol) {
-    if (!Reflect.hasOwnMetadata(fixedWidthVariableKey, target.constructor, fixedWidthVariableKey)) {
-      Reflect.defineMetadata(fixedWidthVariableKey, [], target.constructor, fixedWidthVariableKey);
+    if (!Reflect.hasOwnMetadata(fixedWidthVariableKey, target.constructor)) {
+      // put field list on the class.
+      Reflect.defineMetadata(fixedWidthVariableKey, [], target.constructor);
     }
-    Reflect.getOwnMetadata(fixedWidthVariableKey, target.constructor, fixedWidthVariableKey).push(propertyKey);
+    Reflect.getOwnMetadata(fixedWidthVariableKey, target.constructor).push(propertyKey);
+    // put options on the class's propertyKey property.
     Reflect.defineMetadata(fixedWidthMetadataKey, options, target, propertyKey);
   };
 }


### PR DESCRIPTION
remove the unnecessary 4th field when registering the fields on target's constructor. 